### PR TITLE
Fixed inversion of "N kmers" and "N unique kmers" columns in the sample/table view

### DIFF
--- a/R/datainput-read_report.R
+++ b/R/datainput-read_report.R
@@ -479,7 +479,7 @@ read_report <- function(myfile, has_header=NULL, check_file = FALSE) {
     if (ntabs == 5) {
       col_names <-  c("percentage","cladeReads","taxonReads","taxRank","taxID","name")
     } else if (ntabs == 7) {
-      col_names <- c("percentage","cladeReads","taxonReads", "n_unique_kmers","n_kmers", "taxRank","taxID","name")
+      col_names <- c("percentage","cladeReads","taxonReads","n_kmers", "n_unique_kmers", "taxRank","taxID","name")
     } 
     report <- tryCatch({
       utils::read.table(myfile,sep="\t",header = F,


### PR DESCRIPTION
In the manual of Kraken2 "Distinct minimizer count information": 
- **Column 4**: Number of minimizers in read data associated with this taxon
- **Column 5**: An estimate of the number of distinct minimizers in read data associated with this taxon

These columns were inverted.

